### PR TITLE
Increase max length of description fields

### DIFF
--- a/admin/src/components/CategoryAccordion/index.js
+++ b/admin/src/components/CategoryAccordion/index.js
@@ -12,7 +12,7 @@ import Trash from "@strapi/icons/Trash"
 import Plus from "@strapi/icons/Plus"
 
 // Lodash
-import { first } from "lodash"
+import { first, truncate } from "lodash"
 
 // Utils
 import { getTrad } from "../../utils";
@@ -72,7 +72,7 @@ const CategoryAccordion = ({ cookies, category, setCategory, setCookies, expande
           </Stack>
         }
         title={category.name}
-        description={category.description}
+        description={truncate(category.description, { length: 175 })}
         togglePosition="left"
       />
       <AccordionContent>

--- a/admin/src/components/CategoryModal/index.js
+++ b/admin/src/components/CategoryModal/index.js
@@ -146,6 +146,7 @@ const Modal = ({ setShowModal, crudAction, category = {}, locale = null }) => {
               handleValidation({ description: e.target.value }, setDescriptionValidation, descriptionValidation)
               setDescription(e.target.value)
             }}
+            style={{ minHeight: "200px", height: "auto" }}
             value={description}
           />
         </Box>

--- a/admin/src/components/CategoryModal/validation.js
+++ b/admin/src/components/CategoryModal/validation.js
@@ -27,7 +27,7 @@ const ValidationSchema = (formatMessage) => {
 
     description: Yup
       .string()
-      .max(250, msg.string.isMax),
+      .max(2000, msg.string.isMax),
   })
 };
 

--- a/admin/src/components/CookieModal/validation.js
+++ b/admin/src/components/CookieModal/validation.js
@@ -44,7 +44,7 @@ const ValidationSchema = (formatMessage) => {
 
     description: Yup
       .string()
-      .max(140, msg.string.isMax),
+      .max(2000, msg.string.isMax),
 
     host: Yup
       .string()

--- a/admin/src/components/CookieTable/index.js
+++ b/admin/src/components/CookieTable/index.js
@@ -18,6 +18,9 @@ import Pencil from "@strapi/icons/Pencil";
 import Trash from "@strapi/icons/Trash";
 import Duplicate from "@strapi/icons/Duplicate";
 
+// Lodash
+import { truncate } from "lodash"
+
 // Utils
 import { getTrad } from "../../utils";
 
@@ -196,13 +199,13 @@ const CookieTable = ({
             />
           </Td>
           <Td>
-            <Typography textColor="neutral800">{cookie.name}</Typography>
+            <Typography textColor="neutral800">{truncate(cookie.name, { length: 20 })}</Typography>
           </Td>
           <Td>
-            <Typography textColor="neutral800">{cookie.description}</Typography>
+            <Typography textColor="neutral800">{truncate(cookie.description, { length: 20 })}</Typography>
           </Td>
           <Td>
-            <Typography textColor="neutral800">{cookie.host}</Typography>
+            <Typography textColor="neutral800">{truncate(cookie.host, { length: 20 })}</Typography>
           </Td>
           <Td style={{ justifyContent: "end" }}>
             <Switch

--- a/admin/src/components/PopupContentModal/index.js
+++ b/admin/src/components/PopupContentModal/index.js
@@ -31,7 +31,6 @@ import { getTrad } from "../../utils";
 import validationSchema from "./validation"
 
 const PopupContentModal = ({ setShowModal, createPopup, updatePopup, popup = {}, locale = null }) => {
-  console.log("Popup: ", popup)
 
   const { formatMessage } = useIntl();
   const isUpdate = (Object.keys(popup).length > 0)
@@ -149,6 +148,7 @@ const PopupContentModal = ({ setShowModal, createPopup, updatePopup, popup = {},
                   setDescription(e.target.value)
                 }}
                 value={description}
+                style={{ minHeight: "200px", height: "auto" }}
               />
             </Box>
           </>

--- a/admin/src/components/PopupContentModal/validation.js
+++ b/admin/src/components/PopupContentModal/validation.js
@@ -27,7 +27,7 @@ const ValidationSchema = (formatMessage) => {
 
     description: Yup
       .string()
-      .max(250, msg.string.isMax),
+      .max(2000, msg.string.isMax),
   })
 };
 


### PR DESCRIPTION
This change increases the max length of description fields regarding cookie, category and popup. Also includes visual improvements for long content by truncating.

Issue: [Cookie description max length is too small #7](https://github.com/eigengrau-ch/strapi-plugin-cookie-manager/issues/7)