### PR TITLE
Upgrade engines for Node 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "https://eigengrau.ch"
   },
   "engines": {
-    "node": ">=12.x.x <=16.x.x",
+    "node": ">=12.x.x <=18.x.x",
     "npm": ">=6.0.0"
   },
   "bugs": {


### PR DESCRIPTION
Currently your plugin only allows node 16, just a quick fix up to node 18