### PR TITLE
Fix error in the cookie modal during creation a new cookie

### DIFF
--- a/admin/src/components/CookieModal/index.js
+++ b/admin/src/components/CookieModal/index.js
@@ -243,7 +243,6 @@ const Modal = ({ setShowModal, crudAction, categories, locale = null, preservedC
               defaultMessage: "Category"
             })}
             name="category"
-            required
             error={first(categoryValidation)}
             onChange={(value) => {
               handleValidation({ category: value }, setCategoryValidation)
@@ -267,7 +266,6 @@ const Modal = ({ setShowModal, crudAction, categories, locale = null, preservedC
               defaultMessage: "Party"
             })}
             name="party"
-            required
             error={first(partyValidation)}
             onChange={value => {
               handleValidation({ party: value }, setPartyValidation)


### PR DESCRIPTION
We don't need a built in validation, because it will be checked by the validation rules. At the same time it brakes the logic in some installations.