### PR TITLE
Fix 'destroy is not a function' issue due to async useEffect calls

### DIFF
--- a/admin/src/components/CookieTab/index.js
+++ b/admin/src/components/CookieTab/index.js
@@ -106,14 +106,12 @@ const CookieTab = ({ locale }) => {
     if (!stateExists) setExpandedStates([{ id: id, isExpanded: isExpanded }, ...expandedStates])
   }
 
-  useEffect(async () => {
-    await setCategories()
-    await setCookies()
+  useEffect(() => {
+    setCategories().then(setCookies)
   }, [])
 
-  useEffect(async () => {
-    await setCategories()
-    await setCookies()
+  useEffect(() => {
+    setCategories().then(setCookies)
   }, [locale])
 
   const isLoading = !(!cookieIsLoading && !categoryIsLoading)

--- a/admin/src/components/PopupTab/index.js
+++ b/admin/src/components/PopupTab/index.js
@@ -66,12 +66,12 @@ const PopupTab = ({ locale }) => {
     await setPopups()
   }
 
-  useEffect(async () => {
-    await setPopups()
+  useEffect(() => {
+    setPopups()
   }, [])
 
-  useEffect(async () => {
-    await setPopups()
+  useEffect(() => {
+    setPopups()
   }, [locale])
 
   const isLoading = !(!popupIsLoading)

--- a/admin/src/pages/HomePage/index.js
+++ b/admin/src/pages/HomePage/index.js
@@ -47,9 +47,8 @@ const HomePage = () => {
     setConfigIsLoading(false)
   }
 
-  useEffect(async () => {
-    await getConfig()
-    await getLocales()
+  useEffect(() => {
+    getConfig().then(getLocales)
   }, [])
 
   const isLoading = !(!configIsLoading && !localeIsLoading)

--- a/admin/src/pages/SettingsPage/index.js
+++ b/admin/src/pages/SettingsPage/index.js
@@ -67,8 +67,8 @@ const SettingsPage = () => {
     }
   }
 
-  useEffect(async () => {
-    await getConfigData()
+  useEffect(() => {
+    getConfigData()
   }, [])
 
   return (


### PR DESCRIPTION
Relatively to issue #21, the problem seems to be the one described here : https://stackoverflow.com/questions/58495238/getting-error-after-i-put-async-function-in-useeffect

After removing the async useEffect calls, this issue seems to be fixed.